### PR TITLE
Nav dropdown close fix

### DIFF
--- a/src/components/Navigation/Navigation.css
+++ b/src/components/Navigation/Navigation.css
@@ -40,6 +40,10 @@
   padding: 8px 0;
 }
 
-.navlink .dropdown-link {
+.navlink .dropdown-item .dropdown-link {
+  color: #000;
+}
+
+.dropdown-item .dropdown-link {
   color: #000;
 }

--- a/src/components/Navigation/Navigation.css
+++ b/src/components/Navigation/Navigation.css
@@ -43,7 +43,3 @@
 .navlink .dropdown-item .dropdown-link {
   color: #000;
 }
-
-.dropdown-item .dropdown-link {
-  color: #000;
-}

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -32,13 +32,17 @@ const Navigation: React.FC = () => {
             <Link className="navlink" to="/assessment">
               ASSESSMENTS
             </Link>
-            <NavDropdown className="navlink" title="TRAINING" id="nav-dropdown" style={{ padding: 0 }}>
-              <Link to="/training/scaled-agile" className="dropdown-link dropdown-item">
+            <NavDropdown className="navlink"  title="TRAINING" id="nav-dropdown" style={{ padding: 0 }}>
+              <NavDropdown.Item className="dropdown-item">              
+              <Link to="/training/scaled-agile" className="dropdown-link">
                 Scaled Agile Training
               </Link>
-              <Link to="/training/LeSS" className="dropdown-link dropdown-item">
+              </NavDropdown.Item>
+              <NavDropdown.Item className="dropdown-item">
+              <Link to="/training/LeSS" className="dropdown-link">
                 LeSS Training
               </Link>
+              </NavDropdown.Item>
             </NavDropdown>
             <Link
               className="navlink"


### PR DESCRIPTION
The training dropdown required an extra click on the page to close the dropdown after selection. 
Added Nav.Item elements around links and updated associated css accordingly to keep the same look while adding the close on selection behavior. 